### PR TITLE
Rewrite exit checks for filter loading

### DIFF
--- a/sandbox_linux.go
+++ b/sandbox_linux.go
@@ -8,6 +8,7 @@ import "C"
 import (
 	"github.com/seccomp/libseccomp-golang"
 	"log"
+	"syscall"
 )
 
 var ActTrap = seccomp.ActTrap
@@ -68,9 +69,11 @@ func Jail(sandboxProfile SandboxProfile) {
 	filter.SetTsync(true)
 	filter.SetNoNewPrivsBit(true)
 	err = filter.Load()
-	if err != nil {
-		log.Fatalf("Error loading filter: %s", err)
+	errBadFilter, ok := err.(syscall.Errno)
+	if ok {
+		log.Printf("Failed to load seccomp filter, seccomp (filter mode) not supported by kernel: %d. Sandbox features disabled.",
+			int(errBadFilter))
 	} else {
-		log.Printf("Loaded filter\n")
+		log.Fatalf("Filter context is invalid: %s", errBadFilter)
 	}
 }


### PR DESCRIPTION
This issue fixes #5 - add code to check for two possible failure cases:
filter context is invalid or seccomp syscall failed
